### PR TITLE
Add support for non-tagged v0.0.0 versions

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
 Copyright (C) 2021-2022  Ambassador Labs
+Copyright (C) 2023  Luke Shumaker <lukeshu@lukeshu.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/borrowed_git.go
+++ b/borrowed_git.go
@@ -1,5 +1,6 @@
 // Copyright (C) 2018 The Go Authors. All rights reserved.
 // Copyright (C) 2021-2022  Ambassador Labs
+// Copyright (C) 2023  Luke Shumaker <lukeshu@lukeshu.com>
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the NOTICE file.
@@ -124,8 +125,7 @@ func mostRecentTag(ctx context.Context, commit *commitInfo, dirPrefix string) (s
 		return "", err
 	}
 	if highest == "" {
-		return "", fmt.Errorf("no %q tags are reachable from %q",
-			dirPrefix+"v{SEMVER}", commit.Hash)
+		return "", nil
 	}
 	return dirPrefix + highest, nil
 }
@@ -144,8 +144,7 @@ func mostRecentTags(ctx context.Context, commit *commitInfo, dirPrefix string) (
 		return nil, err
 	}
 	if len(semtags) == 0 {
-		return nil, fmt.Errorf("no %q tags are reachable from %q",
-			dirPrefix+"v{SEMVER}", commit.Hash)
+		return nil, nil
 	}
 	sort.SliceStable(semtags, func(i, j int) bool {
 		return semver.Compare(semtags[i], semtags[j]) > 0


### PR DESCRIPTION
> This is on top of https://github.com/emissary-ingress/goversion/pull/1, go merge that first!

This was never an issue for Emissary, Envoy Gateway, or any of the other projects that have been using `goversion`, because they all have had tags since before adopting `goversion`.  But that's no reason to leave un-tagged repos in the dark!